### PR TITLE
CI enhancements

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,92 +15,63 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "gh-pages"
+  group: "gh-pages" # this is basically a mutex key
   cancel-in-progress: false
 
 jobs:
-  setup:
+  test:
     runs-on: ubuntu-latest
     
-    environment: github-pages
-
-    strategy: # TODO: strategy needs to be moved out of setup job
-      matrix:
-        node-version: [v20.x]  # can add different versions of node here
+    environment: github-pages # for importing any relevant environment variables (use env object)
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
     
-    - name: Setup Node.js ${{ matrix.node-version }}
+    - name: Setup Node.js ${{ env.USE_NODE_VERSION }}
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: ${{ env.USE_NODE_VERSION }}
         cache: 'npm'
         
     - name: Install Dependencies
       run: npm ci
 
-    - name: Save Runner # each step runs on a fresh instance (possibly just merge setup and testing?)
-      uses: actions/cache/save@v4
-      with:
-        path: ~/
-        key: ${{ github.sha }}
-
-  test:
-    needs: setup
-
-    runs-on: ubuntu-latest
-    
-    environment: github-pages
-
-    steps:
-    - name: Restore Runner
-      uses: actions/cache/restore@v4
-      id: restore-cache
-      with:
-        path: ~/
-        key: ${{ github.sha }} # TODO: handle a cache miss by manually setting up again
-        fail-on-cache-miss: true
-
-
-    - name: Run Node.js Tests # TODO: Decide on and add a testing framework, both for the React frontend and the Node.js / C++ / WASM backend
+    - name: Run Node.js Tests # TODO: We've decided on Mocha.js + Chai?
       run: npm run test
-
-    - name: Save Runner
-      uses: actions/cache/save@v4
-      with:
-        path: ~/
-        key: ${{ steps.restore-cache.outputs.cache-primary-key }}
       
   build:
-    needs: [test, setup]
-
     runs-on: ubuntu-latest
     
     environment: github-pages
 
     steps:
-    - name: Restore Runner
-      uses: actions/cache/restore@v4
-      id: restore-cache
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js ${{ env.USE_NODE_VERSION }}
+      uses: actions/setup-node@v4
       with:
-        path: ~/
-        key: ${{ github.sha }} # TODO: handle a cache miss by setting up and testing again
-        fail-on-cache-miss: true
+        node-version: ${{ env.USE_NODE_VERSION }}
+        cache: 'npm'
+
+    - name: Install Dependencies
+      run: npm ci
 
     - name: Transpile Typescript + Build w/ Vite
       run: npm run build
 
     - name: Upload Build Artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v4
       with: 
         path: ./dist  # Vite deploys to dist, not build folder
+        name: github-pages-${{ github.sha }}
+        retention-days: 90
 
       # no need to save runner here since deployment doesn't require the project (the artifact has been uploaded)
 
   deploy:
-    needs: [test, setup, build]
+    needs: [test, build]
 
     runs-on: ubuntu-latest
 
@@ -112,3 +83,5 @@ jobs:
     - name: Deploy to GitHub Pages
       id: deployment
       uses: actions/deploy-pages@v4
+      with:
+        artifact_name: github-pages-${{ github.sha }}


### PR DESCRIPTION
- Merged `setup` and `test` actions since setup standalone has been declared useless: https://github.com/Speyedr/viziou/issues/6#issuecomment-2257853967

- Removed all uses of caching when hopping across tasks since it actually takes longer than just checking out again and installing cached dependencies. Resolves #6, resolves #8

- Removed use of strategy matrix since all versions of Node.js below 20.x are deprecated anyways, and at the moment 22.x has shaky support. Additionally, we only really *need* one version of Node.js at the moment.

- Node.js version is now controlled by the environment variable `USE_NODE_VERSION`, which is currently set to `20.x`. This can be changed by updating the variable in the `github-pages` environment: https://github.com/Speyedr/viziou/settings/environments

- Since caching has been removed, the `build` job now has to checkout, setup Node.js, and re-install dependencies again. It may seem wasteful, but all of these steps are actually just as, if not faster than downloading the runner cache.

- Removed the requirement for `test` to pass in order to `build`. Will see if this changes anything, at the moment the build and testing steps take a handful of seconds each, so it's not like it matters much anyway.

- Added `GITHUB_SHA` to the `github-pages` artifact filename to allow retention of multiple build artifacts instead of immediately overriding old ones by using the same artifact name. Resolves #7

- Bumped `actions/upload-pages-artifact` to v4. Pretty sure dependabot didn't update this action because v4 requires unique filenames and we previously didn't have that.