### PR TITLE
Revert errornous `actions/upload-pages-artifact` bump

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,7 +62,7 @@ jobs:
       run: npm run build
 
     - name: Upload Build Artifact
-      uses: actions/upload-pages-artifact@v4
+      uses: actions/upload-pages-artifact@v3
       with: 
         path: ./dist  # Vite deploys to dist, not build folder
         name: github-pages-${{ github.sha }}


### PR DESCRIPTION
I misread the `action.yml` file, turns out this action *hasn't* actually updated to v4, which explains why dependabot didn't suggest updating it, lol. Should've looked at the Releases page instead, which showed that the most recent version is `v3.0.1`.