### PR TITLE
`packages.json` housekeeping, module override hack to remove deprecated `inflight` dependancy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "hello-world-react-ts",
+  "name": "viziou",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "hello-world-react-ts",
+      "name": "viziou",
       "version": "0.0.0",
       "dependencies": {
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hello-world-react-ts",
+  "name": "viziou",
   "private": true,
   "version": "0.0.0",
   "type": "module",


### PR DESCRIPTION
It seems that there are forces at play far greater than this team as an 8-year old node module, [inflight](https://www.npmjs.com/package/inflight) with 44 million _weekly_ downloads was recently marked as deprecated by the developer, and projects around the world are being pushed to migrate from this module to alternatives.

Running `npm ci` produces multiple deprecation warnings, the relevant ones being:
```
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
[...]
```

This is due to `inflight` being used by `glob 7` which is used by `rimraf 3`... you get the idea.
```
> npm explain inflight
inflight@1.0.6 dev
node_modules/inflight
  inflight@"^1.0.4" from glob@7.2.3
  node_modules/glob
    glob@"^7.1.3" from rimraf@3.0.2
    node_modules/rimraf
      rimraf@"^3.0.2" from flat-cache@3.2.0
      node_modules/flat-cache
        flat-cache@"^3.0.4" from file-entry-cache@6.0.1
        node_modules/file-entry-cache
          file-entry-cache@"^6.0.1" from eslint@8.57.0
          node_modules/eslint
            dev eslint@"^8.57.0" from the root project
[...]
```

The dependancy tree bubbles up to ESLint 8. The problem? [Next.js doesn't currently support ESLint 9](https://github.com/vercel/next.js/issues/64409). And so, there is no immediate fix to this issue other than waiting.

An override has been suggested to use `rimraf 4` instead, as this uses `glob 9`.

```
> npm explain glob 
glob@9.3.5 dev
node_modules/glob
  glob@"^9.2.0" from rimraf@4.4.1
  node_modules/rimraf
    overridden rimraf@"^4.0.0" (was "^3.0.2") from flat-cache@3.2.0
    node_modules/flat-cache
      flat-cache@"^3.0.4" from file-entry-cache@6.0.1
      node_modules/file-entry-cache
        file-entry-cache@"^6.0.1" from eslint@8.57.0
        node_modules/eslint
          dev eslint@"^8.57.0" from the root project
```

There still remain two more deprecation warnings...
```
npm warn deprecated @humanwhocodes/config-array@0.11.14: Use @eslint/config-array instead
npm warn deprecated @humanwhocodes/object-schema@2.0.3: Use @eslint/object-schema instead
```
...however these are directly used by ESLint, and so there is no workaround.

An issue has been created #27 to monitor Next.js' progress, and I have subscribed to the thread in hopes of beng notified when the issue is closed.