### PR TITLE
Possible workaround for Linux shell error when launching Mocha

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -2,5 +2,6 @@
   "loader": "ts-node/esm",
   "require": [
     "mocha.cjs"
-  ]
+  ],
+  "spec": "test/**/*.test.[jt]s?(x)"
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "test": "cross-env TS_NODE_PROJECT='tsconfig.mocha.json' mocha test/**/*.test.[jt]s?(x)"
+    "test": "cross-env TS_NODE_PROJECT='tsconfig.mocha.json' mocha"
   },
   "dependencies": {
     "react": "^18.3.1",


### PR DESCRIPTION
Didn't wrap the glob pattern in quotation marks which probably caused the error, but I decided that moving it into the `.mocharc.json` file is probably better regardless.