### PR TITLE
Update dependabot.yml to use more convenient update time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,15 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "12:00" # midday, which is about when I go to lunch
+      timezone: "Australia/Melbourne"
 
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "12:00"
+      timezone: "Australia/Melbourne"


### PR DESCRIPTION
Running updates at 9 PM, which is basically just after we've finished our meeting is a bit awkward since we would have to wait a whole week before being able to make any group decisions on whether to update certain packages.

Since I mainly manage the repo I've updated the times to fit my schedule so I can check any updates over lunch. It also gives time to prepare any inclusions for the meeting that night.